### PR TITLE
Fix: Bots spawning in the wild

### DIFF
--- a/Data/Profiles/SpawnGroups/Bots/AS2-B3-Bots.sbc
+++ b/Data/Profiles/SpawnGroups/Bots/AS2-B3-Bots.sbc
@@ -11,6 +11,7 @@
                         
                 [CreatureSpawn:true]
                 [CreatureIds:Police_Bot]
+				[AdminSpawnOnly:true]
                 [AiEnabledModBots:true]
                 [AiEnabledRole:SOLDIER]
                 [FactionOwner:QARC]
@@ -48,6 +49,7 @@
                         
                 [CreatureSpawn:true]
                 [CreatureIds:Space_Skeleton]
+				[AdminSpawnOnly:true]
                 [AiEnabledModBots:true]
                 [AiEnabledRole:GRINDER]
                 [FactionOwner:QARC]
@@ -85,6 +87,7 @@
                         
                 [CreatureSpawn:true]
                 [CreatureIds:Boss_Bot]
+				[AdminSpawnOnly:true]
                 [AiEnabledModBots:true]
                 [AiEnabledRole:BRUISER]
                 [FactionOwner:QARC]

--- a/Data/Profiles/Spawner/AS2-B3-Spawner.sbc
+++ b/Data/Profiles/Spawner/AS2-B3-Spawner.sbc
@@ -231,6 +231,7 @@
                 [SpawnMinCooldown:1]
                 [SpawnMaxCooldown:2]
                 [MaxSpawns:-1]
+				[ProcessAsAdminSpawn:true]
                 [SpawningType:Creature]
                 [SpawnGroups:AS2-B3-Guard-Bot]
                 [SpawnGroups:AS2-B3-Boss-Bot]
@@ -248,6 +249,7 @@
                 [SpawnMinCooldown:1]
                 [SpawnMaxCooldown:2]
                 [MaxSpawns:-1]
+				[ProcessAsAdminSpawn:true]
                 [SpawningType:Creature]
                 [SpawnGroups:AS2-B3-Grinder-Bot]
             </Description>


### PR DESCRIPTION
edge case where aiEnabled bots may ignore threat score conditions and spawn in the wild.  Borrowed the undocumented ProcessAsAdminSpawn constraint from Robot Raider Pods.